### PR TITLE
chore: clone last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ php:
   - 7.2
   - 7.2snapshot
 
+git:
+  depth: 5
+
 branches:
   only:
     - master


### PR DESCRIPTION
By default Travis CI clones the last 50 commits (depth = 50). Cloning 5 is also sufficient and often faster.

See https://docs.travis-ci.com/user/customizing-the-build#Git-Clone-Depth

## Proposed Changes

- clone only the last 5 commits